### PR TITLE
add bodyClass and autoPrint options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperizer",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperizer",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.3.4"

--- a/src/composables/options.ts
+++ b/src/composables/options.ts
@@ -11,6 +11,7 @@ const useOptions = (options?: PaperizerOption) => {
   const features = ref<string>('')
   const windowTitle = ref<string | undefined>('')
   const autoClose = ref(true)
+  const bodyClass = ref<string>('')
 
   const filteredFeatures = (features: string[]) => {
     return features?.filter((feature) => feature)
@@ -22,12 +23,14 @@ const useOptions = (options?: PaperizerOption) => {
   )
   windowTitle.value = options?.windowTitle || defaultWindowTitle
   autoClose.value = options?.autoClose ?? defaultAutoClose
+  bodyClass.value = options?.bodyClass ?? ''
 
   return {
     target: target.value,
     features: features.value,
     windowTitle: windowTitle.value,
-    autoClose: autoClose.value
+    autoClose: autoClose.value,
+    bodyClass: bodyClass.value,
   }
 }
 

--- a/src/composables/options.ts
+++ b/src/composables/options.ts
@@ -6,12 +6,14 @@ const useOptions = (options?: PaperizerOption) => {
   const defaultFeatures = ['fullscreen=yes', 'titlebar=yes', 'scrollbars=yes']
   const defaultWindowTitle = window.document.title
   const defaultAutoClose = true
+  const defaultAutoPrint = true
 
   const target = ref<string>('')
   const features = ref<string>('')
   const windowTitle = ref<string | undefined>('')
   const autoClose = ref(true)
   const bodyClass = ref<string>('')
+  const autoPrint = ref(true)
 
   const filteredFeatures = (features: string[]) => {
     return features?.filter((feature) => feature)
@@ -24,6 +26,7 @@ const useOptions = (options?: PaperizerOption) => {
   windowTitle.value = options?.windowTitle || defaultWindowTitle
   autoClose.value = options?.autoClose ?? defaultAutoClose
   bodyClass.value = options?.bodyClass ?? ''
+  autoPrint.value = options?.autoPrint ?? defaultAutoPrint
 
   return {
     target: target.value,
@@ -31,6 +34,7 @@ const useOptions = (options?: PaperizerOption) => {
     windowTitle: windowTitle.value,
     autoClose: autoClose.value,
     bodyClass: bodyClass.value,
+    autoPrint: autoPrint.value,
   }
 }
 

--- a/src/composables/windowContent.ts
+++ b/src/composables/windowContent.ts
@@ -1,11 +1,11 @@
 const useWindowContent = () => {
-  const writeWindowContent = (window: Window, element: HTMLElement) => {
+  const writeWindowContent = (window: Window, element: HTMLElement, bodyClass: string) => {
     window.document.write(`
       <html>
         <head>
           <title>${window.document.title}</title>
         </head>
-        <body>
+        <body class="${bodyClass}">
           ${element.innerHTML}
         </body>
       </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,15 +12,15 @@ export const usePaperizer = (
   callBack: Function = () => {}
 ): { paperize: () => void } => {
   const windowWithLocalOptions = (options?: PaperizerOption) => {
-    const { target, features, windowTitle, autoClose, bodyClass } = useOptions(options)
+    const { target, features, windowTitle, autoClose, bodyClass, autoPrint } = useOptions(options)
     const { previewWindow } = useWindow(target, features)
 
-    return { defaultWindow: previewWindow.value, target, windowTitle, autoClose, bodyClass }
+    return { defaultWindow: previewWindow.value, target, windowTitle, autoClose, bodyClass, autoPrint }
   }
 
   const paperize = (): void => {
     const { selectedElement } = useComponent(elementId)
-    const { defaultWindow, target, windowTitle, autoClose, bodyClass } =
+    const { defaultWindow, target, windowTitle, autoClose, bodyClass, autoPrint } =
       windowWithLocalOptions(options)
     const { writeWindowContent } = useWindowContent()
     const { attachStyles } = useStyle()
@@ -32,12 +32,14 @@ export const usePaperizer = (
       setTimeout(() => {
         defaultWindow.document.close()
         defaultWindow.focus()
-        defaultWindow.print()
-        setTimeout(function () {
-          if (target !== '_blank') return
-
-          if (autoClose) defaultWindow.close()
-        }, 1)
+        if(autoPrint){
+          defaultWindow.print()
+          setTimeout(function () {
+            if (target !== '_blank') return
+  
+            if (autoClose) defaultWindow.close()
+          }, 1)
+        } 
         callBack()
       }, 1000)
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,22 +12,22 @@ export const usePaperizer = (
   callBack: Function = () => {}
 ): { paperize: () => void } => {
   const windowWithLocalOptions = (options?: PaperizerOption) => {
-    const { target, features, windowTitle, autoClose } = useOptions(options)
+    const { target, features, windowTitle, autoClose, bodyClass } = useOptions(options)
     const { previewWindow } = useWindow(target, features)
 
-    return { defaultWindow: previewWindow.value, target, windowTitle, autoClose }
+    return { defaultWindow: previewWindow.value, target, windowTitle, autoClose, bodyClass }
   }
 
   const paperize = (): void => {
     const { selectedElement } = useComponent(elementId)
-    const { defaultWindow, target, windowTitle, autoClose } =
+    const { defaultWindow, target, windowTitle, autoClose, bodyClass } =
       windowWithLocalOptions(options)
     const { writeWindowContent } = useWindowContent()
     const { attachStyles } = useStyle()
 
     if (defaultWindow && selectedElement.value) {
       defaultWindow.document.title = windowTitle || document.title
-      writeWindowContent(defaultWindow, selectedElement.value)
+      writeWindowContent(defaultWindow, selectedElement.value, bodyClass)
       attachStyles(defaultWindow, options?.styles)
       setTimeout(() => {
         defaultWindow.document.close()

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -34,4 +34,11 @@ export interface PaperizerOption {
    *
    */
   windowTitle?: string
+
+  /**
+   *
+   * Adds a custom body class to the print preview window.
+   *
+   */
+  bodyClass?: string
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -41,4 +41,6 @@ export interface PaperizerOption {
    *
    */
   bodyClass?: string
+
+  autoPrint?: boolean
 }


### PR DESCRIPTION
Adding bodyClass can be used with papercss to set paper size. Adding autoPrint can preview but not print directly.